### PR TITLE
Add spinnerMode configuration

### DIFF
--- a/ImageViewer/Source/GalleryConfiguration.swift
+++ b/ImageViewer/Source/GalleryConfiguration.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 public typealias GalleryConfiguration = [GalleryConfigurationItem]
+public typealias ActivityIndicatorCompletion = (() -> Void)
 
 public enum GalleryConfigurationItem {
 
@@ -183,7 +184,7 @@ public enum SpinnerMode {
     
     case none
     case system // UIActivityIndicatorView
-    case custom(UIView, () -> Void)
+    case custom(UIView, ActivityIndicatorCompletion)
 }
 
 public enum GalleryPagingMode {

--- a/ImageViewer/Source/GalleryConfiguration.swift
+++ b/ImageViewer/Source/GalleryConfiguration.swift
@@ -48,6 +48,9 @@ public enum GalleryConfigurationItem {
     /// Tint color for the spinner.
     case spinnerColor(UIColor)
 
+    /// Option to hide spinner or set a custom spinner. SpinnerStyle and spinnerColor configurations will ignore for custom view. Default is SpinnerMode.system.
+    case spinnerMode(SpinnerMode)
+
     /// Layout behaviour for optional header view.
     case headerViewLayout(HeaderLayout)
 
@@ -174,6 +177,13 @@ public enum ButtonMode {
     case none
     case builtIn /// Standard Close or Thumbnails button.
     case custom(UIButton)
+}
+
+public enum SpinnerMode {
+    
+    case none
+    case system // UIActivityIndicatorView
+    case custom(UIView, () -> Void)
 }
 
 public enum GalleryPagingMode {

--- a/ImageViewer/Source/ItemBaseController.swift
+++ b/ImageViewer/Source/ItemBaseController.swift
@@ -19,6 +19,8 @@ open class ItemBaseController<T: UIView>: UIViewController, ItemController, UIGe
     public var itemView = T()
     let scrollView = UIScrollView()
     let activityIndicatorView = UIActivityIndicatorView(activityIndicatorStyle: .white)
+    fileprivate var customActivityIndicatorView: UIView?
+    fileprivate var customActivityIndicatorCompletion: (() -> Void)?
 
     //DELEGATE / DATASOURCE
     weak public var delegate:                 ItemControllerDelegate?
@@ -49,6 +51,7 @@ open class ItemBaseController<T: UIView>: UIViewController, ItemController, UIGe
     fileprivate var swipeToDismissMode = GallerySwipeToDismissMode.always
     fileprivate var toggleDecorationViewBySingleTap = true
     fileprivate var activityViewByLongPress = true
+    fileprivate var spinnerMode = SpinnerMode.system
 
     /// INTERACTIONS
     fileprivate var singleTapRecognizer: UITapGestureRecognizer?
@@ -89,6 +92,15 @@ open class ItemBaseController<T: UIView>: UIViewController, ItemController, UIGe
             case .activityViewByLongPress(let enabled):             activityViewByLongPress = enabled
             case .spinnerColor(let color):                          activityIndicatorView.color = color
             case .spinnerStyle(let style):                          activityIndicatorView.activityIndicatorViewStyle = style
+            case .spinnerMode(let mode):
+                self.spinnerMode = mode
+                switch mode {
+                case .custom(let view, let completion):
+                    self.customActivityIndicatorView = view
+                    self.customActivityIndicatorCompletion = completion
+                default:
+                    break
+                }
 
             case .displacementTransitionStyle(let style):
 
@@ -181,8 +193,18 @@ open class ItemBaseController<T: UIView>: UIViewController, ItemController, UIGe
         self.view.addSubview(scrollView)
         scrollView.addSubview(itemView)
 
-        activityIndicatorView.startAnimating()
-        view.addSubview(activityIndicatorView)
+        switch spinnerMode {
+        case .system:
+            activityIndicatorView.isHidden = false
+            activityIndicatorView.startAnimating()
+            view.addSubview(activityIndicatorView)
+        case .custom(_, _):
+            if let customIndicatorView = customActivityIndicatorView {
+                view.addSubview(customIndicatorView)
+            }
+        case .none:
+            activityIndicatorView.isHidden = true
+        }
     }
 
     // MARK: - View Controller Lifecycle
@@ -203,6 +225,10 @@ open class ItemBaseController<T: UIView>: UIViewController, ItemController, UIGe
 
                 DispatchQueue.main.async {
                     self?.activityIndicatorView.stopAnimating()
+
+                    if let customActivityIndicatorCompletion = self?.customActivityIndicatorCompletion {
+                        customActivityIndicatorCompletion()
+                    }
 
                     var itemView = self?.itemView
                     itemView?.image = image
@@ -240,6 +266,10 @@ open class ItemBaseController<T: UIView>: UIViewController, ItemController, UIGe
 
         scrollView.frame = self.view.bounds
         activityIndicatorView.center = view.boundsCenter
+
+        if let customActivityIndicatorView = self.customActivityIndicatorView {
+            customActivityIndicatorView.center = view.boundsCenter
+        }
 
         if let size = itemView.image?.size , size != CGSize.zero {
 

--- a/ImageViewer/Source/ItemBaseController.swift
+++ b/ImageViewer/Source/ItemBaseController.swift
@@ -20,7 +20,7 @@ open class ItemBaseController<T: UIView>: UIViewController, ItemController, UIGe
     let scrollView = UIScrollView()
     let activityIndicatorView = UIActivityIndicatorView(activityIndicatorStyle: .white)
     fileprivate var customActivityIndicatorView: UIView?
-    fileprivate var customActivityIndicatorCompletion: (() -> Void)?
+    fileprivate var customActivityIndicatorCompletion: ActivityIndicatorCompletion?
 
     //DELEGATE / DATASOURCE
     weak public var delegate:                 ItemControllerDelegate?


### PR DESCRIPTION
Sometimes you want to show a loader with the progress bar, for example, or show nothing at all. Let's provide an opportunity to create custom spinners with `SpinnerMode.custom`.

`SpinnerMode` is a new case for `GalleryConfigurationItem`. By default uses logic from previous versions - `SpinnerMode.system`.