### PR TITLE
Change references to MailOnline/ImageViewer to Krisiacik/ImageViewer

### DIFF
--- a/ImageViewer.podspec
+++ b/ImageViewer.podspec
@@ -6,11 +6,10 @@ Pod::Spec.new do |s|
    ImageViewer is a library that enables a user to visualize an image in fullscreen. Besides the typical pinch and double tap to zoom, we also provide a vertical swipe to dismiss. Finally, we try to mimic the displacement of the image from its current container into fullscreen, this feature being its main selling point. We also offer an amazing Gallery, so you can swipe between images.
     EOS
 
-    s.homepage         = "https://github.com/MailOnline/ImageViewer"
+    s.homepage         = "https://github.com/Krisiacik/ImageViewer"
     s.license          = "MIT"
-    s.author           = "MailOnline"
-    s.social_media_url = "https://twitter.com/MailOnline"
-    s.source           = { :git => "https://github.com/MailOnline/ImageViewer.git", :tag => s.version.to_s }
+    s.author           = "Kristian Angyal"
+    s.source           = { :git => "https://github.com/Krisiacik/ImageViewer.git", :tag => s.version.to_s }
 
     s.ios.deployment_target = "8.0"
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 
-[![CI Status](http://img.shields.io/travis/MailOnline/ImageViewer.svg?style=flat)](https://travis-ci.org/MailOnline/ImageViewer)
+[![CI Status](http://img.shields.io/travis/Krisiacik/ImageViewer.svg?style=flat)](https://travis-ci.org/Krisiacik/ImageViewer)
 [![Swift 3.1](https://img.shields.io/badge/Swift-4.0-orange.svg?style=flat)](https://developer.apple.com/swift/)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![Version](https://img.shields.io/cocoapods/v/ImageViewer.svg?style=flat)](http://cocoadocs.org/docsets/ImageViewer)
 [![Platforms iOS](https://img.shields.io/badge/Platforms-iOS-lightgray.svg?style=flat)](https://developer.apple.com/swift/)
 [![License MIT](https://img.shields.io/badge/License-MIT-lightgrey.svg?style=flat)](https://opensource.org/licenses/MIT)
 
-![Single image view](https://github.com/MailOnline/ImageViewer/blob/master/Documentation/single.gif)
+![Single image view](https://github.com/Krisiacik/ImageViewer/blob/master/Documentation/single.gif)
 
-![Gallery](https://github.com/MailOnline/ImageViewer/blob/master/Documentation/gallery.gif)
+![Gallery](https://github.com/Krisiacik/ImageViewer/blob/master/Documentation/gallery.gif)
 
 For the latest changes see the [CHANGELOG](CHANGELOG.md)
 
@@ -23,12 +23,12 @@ pod 'ImageViewer'
 ### Carthage
 
 ```ruby
-github "MailOnline/ImageViewer"
+github "Krisiacik/ImageViewer"
 ```
 
 ## Sample Usage
 
-For a detailed example, see the [Example](https://github.com/MailOnline/ImageViewer/tree/master/Example)!
+For a detailed example, see the [Example](https://github.com/Krisiacik/ImageViewer/tree/master/Example)!
 
 ```swift
 // Show the ImageViewer with with the first item


### PR DESCRIPTION
These changes primarily fix the README, including various links and the Carthage instructions.
The `.podspec` was also fixed to point to the new location.

**NOTE:** no changes to Copyright notices either in the README or the code were made as I don't know what the copyright status is.