### PR TITLE
Fixed crash in iPad when we tap(Long press) on image viewer in full screen mode

### DIFF
--- a/ImageViewer/Source/GalleryViewController.swift
+++ b/ImageViewer/Source/GalleryViewController.swift
@@ -676,13 +676,28 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
             guard let image = item.image else { return }
             let activityVC = UIActivityViewController(activityItems: [image], applicationActivities: nil)
             self.present(activityVC, animated: true)
+            if UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiom.pad {
+                self.prepareForIpad(source: self.view, to: activityVC)
+            }
 
         case (_ as VideoViewController, let item as VideoView):
             guard let videoUrl = ((item.player?.currentItem?.asset) as? AVURLAsset)?.url else { return }
             let activityVC = UIActivityViewController(activityItems: [videoUrl], applicationActivities: nil)
             self.present(activityVC, animated: true)
+            if UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiom.pad {
+                self.prepareForIpad(source: self.view, to: activityVC)
+            }
 
         default:  return
+        }
+    }
+
+    fileprivate func prepareForIpad(source: UIView, to activityVC: UIActivityViewController) {
+
+        if let popOver = activityVC.popoverPresentationController {
+            popOver.sourceView = source
+            popOver.sourceRect = CGRect(x: source.bounds.midX, y: source.bounds.midY, width: 0, height: 0)
+            popOver.permittedArrowDirections = []
         }
     }
 


### PR DESCRIPTION
Fixed crash in iPad when we we tap(Long press) on image viewer in full screen mode to share the image or video.
This PR solved this issue: https://github.com/Krisiacik/ImageViewer/issues/187