### PR TITLE
Develop

### DIFF
--- a/ImageViewer/Source/GalleryViewController.swift
+++ b/ImageViewer/Source/GalleryViewController.swift
@@ -35,7 +35,7 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
     // DATASOURCE/DELEGATE
     fileprivate weak var itemsDelegate: GalleryItemsDelegate?
     fileprivate weak var itemsDataSource: GalleryItemsDataSource?
-    fileprivate weak var pagingDataSource: GalleryPagingDataSource?
+    fileprivate let pagingDataSource: GalleryPagingDataSource
 
     // CONFIGURATION
     fileprivate var spineDividerWidth:         Float = 10
@@ -152,10 +152,10 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
                    navigationOrientation: UIPageViewControllerNavigationOrientation.horizontal,
                    options: [UIPageViewControllerOptionInterPageSpacingKey : NSNumber(value: spineDividerWidth as Float)])
 
-        pagingDataSource?.itemControllerDelegate = self
+        pagingDataSource.itemControllerDelegate = self
 
         ///This feels out of place, one would expect even the first presented(paged) item controller to be provided by the paging dataSource but there is nothing we can do as Apple requires the first controller to be set via this "setViewControllers" method.
-        let initialController = pagingDataSource!.createItemController(startIndex, isInitial: true)
+        let initialController = pagingDataSource.createItemController(startIndex, isInitial: true)
         self.setViewControllers([initialController], direction: UIPageViewControllerNavigationDirection.forward, animated: false, completion: nil)
 
         if let controller = initialController as? ItemController {
@@ -451,7 +451,7 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
 
     open func page(toIndex index: Int) {
 
-        guard let itemsDataSource = itemsDataSource, let pagingDataSource = pagingDataSource else {
+        guard let itemsDataSource = itemsDataSource else {
             return
         }
         
@@ -480,7 +480,7 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
 
     func removePage(atIndex index: Int, completion: @escaping () -> Void) {
 
-        guard let itemsDataSource = itemsDataSource, let pagingDataSource = pagingDataSource else {
+        guard let itemsDataSource = itemsDataSource else {
             return
         }
         // If removing last item, go back, otherwise, go forward
@@ -559,7 +559,6 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
         }
         itemsDelegate = nil
         itemsDataSource = nil
-        pagingDataSource = nil
 
         UIView.animate(withDuration: decorationViewsFadeDuration, animations: { [weak self] in
 


### PR DESCRIPTION
修正 ImageViewer 套件的 delegate 非 weak 屬性，導致 Memory Leaks.

Fix `GalleryViewController` strong `itemsDelegate` and `itemsDataSource` property cause memory leaks