### PR TITLE
Memory Leak /Retain Cycles resolved

### DIFF
--- a/ImageViewer/Source/GalleryPagingDataSource.swift
+++ b/ImageViewer/Source/GalleryPagingDataSource.swift
@@ -19,14 +19,15 @@ final class GalleryPagingDataSource: NSObject, UIPageViewControllerDataSource {
     fileprivate var itemCount: Int { return itemsDataSource?.itemCount() ?? 0 }
     fileprivate unowned var scrubber: VideoScrubber
 
-    init(itemsDataSource: GalleryItemsDataSource, displacedViewsDataSource: GalleryDisplacedViewsDataSource?, scrubber: VideoScrubber, configuration: GalleryConfiguration) {
+    init(itemsDataSource: GalleryItemsDataSource?, displacedViewsDataSource: GalleryDisplacedViewsDataSource?, scrubber: VideoScrubber, configuration: GalleryConfiguration) {
 
         self.itemsDataSource = itemsDataSource
         self.displacedViewsDataSource = displacedViewsDataSource
         self.scrubber = scrubber
         self.configuration = configuration
 
-        if itemsDataSource.itemCount() > 1 { // Potential carousel mode present in configuration only makes sense for more than 1 item
+        guard let source = itemsDataSource else {return}
+        if source.itemCount() > 1 { // Potential carousel mode present in configuration only makes sense for more than 1 item
 
             for item in configuration {
 

--- a/ImageViewer/Source/GalleryViewController.swift
+++ b/ImageViewer/Source/GalleryViewController.swift
@@ -148,7 +148,7 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
             }
         }
 
-        pagingDataSource = GalleryPagingDataSource(itemsDataSource: self.itemsDataSource!, displacedViewsDataSource: displacedViewsDataSource, scrubber: scrubber, configuration: configuration)
+        pagingDataSource = GalleryPagingDataSource(itemsDataSource:itemsDataSource, displacedViewsDataSource: displacedViewsDataSource, scrubber: scrubber, configuration: configuration)
 
         super.init(transitionStyle: UIPageViewController.TransitionStyle.scroll,
                    navigationOrientation: UIPageViewController.NavigationOrientation.horizontal,

--- a/ImageViewer/Source/GalleryViewController.swift
+++ b/ImageViewer/Source/GalleryViewController.swift
@@ -35,7 +35,7 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
 
     // DATASOURCE/DELEGATE
     fileprivate weak var itemsDelegate: GalleryItemsDelegate?
-    fileprivate let itemsDataSource: GalleryItemsDataSource
+    fileprivate weak var itemsDataSource: GalleryItemsDataSource?
     fileprivate let pagingDataSource: GalleryPagingDataSource
 
     // CONFIGURATION
@@ -69,7 +69,7 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
     @available(*, unavailable)
     required public init?(coder: NSCoder) { fatalError() }
 
-    public init(startIndex: Int, itemsDataSource: GalleryItemsDataSource, itemsDelegate: GalleryItemsDelegate?, displacedViewsDataSource: GalleryDisplacedViewsDataSource? = nil, configuration: GalleryConfiguration = []) {
+    public init(startIndex: Int, itemsDataSource: GalleryItemsDataSource, itemsDelegate: GalleryItemsDelegate? = nil, displacedViewsDataSource: GalleryDisplacedViewsDataSource? = nil, configuration: GalleryConfiguration = []) {
 
         self.currentIndex = startIndex
         self.itemsDelegate = itemsDelegate
@@ -440,8 +440,10 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
     //ThumbnailsimageBlock
 
     @objc fileprivate func showThumbnails() {
+        
+        guard let source = self.itemsDataSource else {return}
 
-        let thumbnailsController = ThumbnailsViewController(itemsDataSource: self.itemsDataSource)
+        let thumbnailsController = ThumbnailsViewController(itemsDataSource: source)
 
         if let closeButton = seeAllCloseButton {
             thumbnailsController.closeButton = closeButton
@@ -464,7 +466,8 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
 
     open func page(toIndex index: Int) {
 
-        guard currentIndex != index && index >= 0 && index < self.itemsDataSource.itemCount() else { return }
+        guard let source = self.itemsDataSource else {return}
+        guard currentIndex != index && index >= 0 && index < source.itemCount() else { return }
 
         let imageViewController = self.pagingDataSource.createItemController(index)
         let direction: UIPageViewController.NavigationDirection = index > currentIndex ? .forward : .reverse
@@ -490,8 +493,8 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
     func removePage(atIndex index: Int, completion: @escaping () -> Void) {
 
         // If removing last item, go back, otherwise, go forward
-
-        let direction: UIPageViewController.NavigationDirection = index < self.itemsDataSource.itemCount() ? .forward : .reverse
+        guard let source = self.itemsDataSource else {return}
+        let direction: UIPageViewController.NavigationDirection = index < source.itemCount() ? .forward : .reverse
 
         let newIndex = direction == .forward ? index : index - 1
 
@@ -502,8 +505,8 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
     }
 
     open func reload(atIndex index: Int) {
-
-        guard index >= 0 && index < self.itemsDataSource.itemCount() else { return }
+        guard let source = self.itemsDataSource else {return}
+        guard index >= 0 && index < source.itemCount() else { return }
 
         guard let firstVC = viewControllers?.first, let itemController = firstVC as? ItemController else { return }
 

--- a/ImageViewer/Source/GalleryViewController.swift
+++ b/ImageViewer/Source/GalleryViewController.swift
@@ -34,8 +34,8 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
     fileprivate var initialPresentationDone = false
 
     // DATASOURCE/DELEGATE
-    fileprivate let itemsDelegate: GalleryItemsDelegate?
-    fileprivate let itemsDataSource: GalleryItemsDataSource
+    fileprivate weak var itemsDelegate: GalleryItemsDelegate?
+    fileprivate weak var itemsDataSource: GalleryItemsDataSource?
     fileprivate weak var pagingDataSource: GalleryPagingDataSource?
 
     // CONFIGURATION
@@ -441,7 +441,9 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
 
     @objc fileprivate func showThumbnails() {
 
-        let thumbnailsController = ThumbnailsViewController(itemsDataSource: self.itemsDataSource)
+        guard let itemsDataSource  =  self.itemsDataSource else {return}
+        
+        let thumbnailsController = ThumbnailsViewController(itemsDataSource: itemsDataSource)
 
         if let closeButton = seeAllCloseButton {
             thumbnailsController.closeButton = closeButton
@@ -464,7 +466,9 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
 
     open func page(toIndex index: Int) {
 
-        guard currentIndex != index && index >= 0 && index < self.itemsDataSource.itemCount() else { return }
+        guard let itemsDataSource  =  self.itemsDataSource else {return}
+        
+        guard currentIndex != index && index >= 0 && index < itemsDataSource.itemCount() else { return }
 
         guard let pagingDataSource = pagingDataSource else { return }
         let imageViewController = pagingDataSource.createItemController(index)
@@ -491,8 +495,9 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
     func removePage(atIndex index: Int, completion: @escaping () -> Void) {
 
         // If removing last item, go back, otherwise, go forward
-
-        let direction: UIPageViewController.NavigationDirection = index < self.itemsDataSource.itemCount() ? .forward : .reverse
+        guard let itemsDataSource  =  self.itemsDataSource else {return}
+        
+        let direction: UIPageViewController.NavigationDirection = index < itemsDataSource.itemCount() ? .forward : .reverse
 
         let newIndex = direction == .forward ? index : index - 1
 
@@ -504,8 +509,10 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
     }
 
     open func reload(atIndex index: Int) {
+        
+        guard let itemsDataSource  =  self.itemsDataSource else {return}
 
-        guard index >= 0 && index < self.itemsDataSource.itemCount() else { return }
+        guard index >= 0 && index < itemsDataSource.itemCount() else { return }
 
         guard let firstVC = viewControllers?.first, let itemController = firstVC as? ItemController else { return }
 

--- a/ImageViewer/Source/GalleryViewController.swift
+++ b/ImageViewer/Source/GalleryViewController.swift
@@ -69,7 +69,7 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
     @available(*, unavailable)
     required public init?(coder: NSCoder) { fatalError() }
 
-    public init(startIndex: Int, itemsDataSource: GalleryItemsDataSource, itemsDelegate: GalleryItemsDelegate? = nil, displacedViewsDataSource: GalleryDisplacedViewsDataSource? = nil, configuration: GalleryConfiguration = []) {
+    public init(startIndex: Int, itemsDataSource: GalleryItemsDataSource? = nil, itemsDelegate: GalleryItemsDelegate? = nil, displacedViewsDataSource: GalleryDisplacedViewsDataSource? = nil, configuration: GalleryConfiguration = []) {
 
         self.currentIndex = startIndex
         self.itemsDelegate = itemsDelegate
@@ -148,7 +148,7 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
             }
         }
 
-        pagingDataSource = GalleryPagingDataSource(itemsDataSource: itemsDataSource, displacedViewsDataSource: displacedViewsDataSource, scrubber: scrubber, configuration: configuration)
+        pagingDataSource = GalleryPagingDataSource(itemsDataSource: self.itemsDataSource!, displacedViewsDataSource: displacedViewsDataSource, scrubber: scrubber, configuration: configuration)
 
         super.init(transitionStyle: UIPageViewController.TransitionStyle.scroll,
                    navigationOrientation: UIPageViewController.NavigationOrientation.horizontal,


### PR DESCRIPTION
For a little while I didn't realize `pagingDataSource` is also holding a reference to itemsDataSource... 

Making  `itemsDelegate` and  `itemsDataSource` weak then passing the weak value to  `GalleryPagingDataSource` resolved my issues. 

Merge it with grain of salt....