### PR TITLE
Change the way current window is retrieved

### DIFF
--- a/ImageViewer/Source/Extensions/UIApplication.swift
+++ b/ImageViewer/Source/Extensions/UIApplication.swift
@@ -11,7 +11,7 @@ import UIKit
 extension UIApplication {
 
     static var applicationWindow: UIWindow {
-        return (UIApplication.shared.delegate?.window?.flatMap { $0 })!
+        return UIApplication.shared.keyWindow!
     }
 
     static var isPortraitOnly: Bool {


### PR DESCRIPTION
The current way of getting application window crashes on nil exception in Xcode 10. `UIApplication.shared.keyWindow` seems to be the standard way to get the current window in swift