### PR TITLE
Added swift version to podspec

### DIFF
--- a/ImageViewer.podspec
+++ b/ImageViewer.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
     s.social_media_url = "https://twitter.com/MailOnline"
     s.source           = { :git => "https://github.com/MailOnline/ImageViewer.git", :tag => s.version.to_s }
 
+    s.swift_version = '4.2'
     s.ios.deployment_target = "8.0"
 
     s.source_files  = "ImageViewer/Source/**/*"


### PR DESCRIPTION
In Swift 5 projects ImageViewer's swift version is assumed to be 5 as well. If explicitly set in podspec ImageViewer compiles successfully even in swift 5 projects