### PR TITLE
Add delegate method for delete confirmation

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -27,6 +27,8 @@ class ViewController: UIViewController {
     @IBOutlet weak var image7: UIImageView!
 
     var items: [DataItem] = []
+    
+    var galleryViewController: GalleryViewController?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -93,6 +95,7 @@ class ViewController: UIViewController {
             footerView.currentIndex = index
         }
 
+        self.galleryViewController = galleryViewController
         self.presentImageGallery(galleryViewController)
     }
 
@@ -178,6 +181,21 @@ extension ViewController: GalleryItemsDelegate {
         let imageView = items[index].imageView
         imageView.removeFromSuperview()
         items.remove(at: index)
+    }
+    
+    func shouldRemoveGalleryItem(at index: Int, block: @escaping (Bool) -> Void) {
+        let alert = UIAlertController(
+            title: "Delete?",
+            message: "Are you sure you want to delete this image?",
+            preferredStyle: .alert
+        )
+        alert.addAction(.init(title: "Delete", style: .destructive) { _ in
+            block(true)
+        })
+        alert.addAction(.init(title: "Cancel", style: .cancel) { _ in
+            block(false)
+        })
+        galleryViewController?.present(alert, animated: true)
     }
 }
 

--- a/ImageViewer/Source/GalleryItemsDelegate.swift
+++ b/ImageViewer/Source/GalleryItemsDelegate.swift
@@ -11,4 +11,11 @@ import Foundation
 public protocol GalleryItemsDelegate: class {
 
     func removeGalleryItem(at index: Int)
+    func shouldRemoveGalleryItem(at index: Int, block: @escaping (Bool) -> Void)
+}
+
+extension GalleryItemsDelegate {
+    func shouldRemoveGalleryItem(at index: Int, block: @escaping (Bool) -> Void) {
+        block(true)
+    }
 }

--- a/ImageViewer/Source/GalleryViewController.swift
+++ b/ImageViewer/Source/GalleryViewController.swift
@@ -424,16 +424,21 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
     }
 
     @objc fileprivate func deleteItem() {
+        
+        itemsDelegate?.shouldRemoveGalleryItem(at: currentIndex) {
+            [weak self] shouldRemove in
+            guard let self = self, shouldRemove else { return }
 
-        deleteButton?.isEnabled = false
-        view.isUserInteractionEnabled = false
+            self.deleteButton?.isEnabled = false
+            self.view.isUserInteractionEnabled = false
 
-        itemsDelegate?.removeGalleryItem(at: currentIndex)
-        removePage(atIndex: currentIndex) {
+            self.itemsDelegate?.removeGalleryItem(at: self.currentIndex)
+            self.removePage(atIndex: self.currentIndex) {
 
-            [weak self] in
-            self?.deleteButton?.isEnabled = true
-            self?.view.isUserInteractionEnabled = true
+                [weak self] in
+                self?.deleteButton?.isEnabled = true
+                self?.view.isUserInteractionEnabled = true
+            }
         }
     }
 


### PR DESCRIPTION
Add delegate method `shouldRemoveGalleryItem` so users can be presented with an alert prior to deleting an image. `shouldRemoveGalleryItem` has a default implementation so that existing users of this library remain unaffected.