### PR TITLE
Added support as Swift Package

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/ImageViewer.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/ImageViewer.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1200"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ImageViewer"
+               BuildableName = "ImageViewer"
+               BlueprintName = "ImageViewer"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "ImageViewer"
+            BuildableName = "ImageViewer"
+            BlueprintName = "ImageViewer"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ImageViewer
 
+
+## Version 6.0.1
+
+* Added support as Swift Package 
+
+
 ## Version 6.0.0
 
 * Upgrade to Swift 5 and fix subsequent compiler warnings

--- a/ImageViewer/Source/GalleryViewController.swift
+++ b/ImageViewer/Source/GalleryViewController.swift
@@ -674,16 +674,32 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
 
         case (_ as ImageViewController, let item as UIImageView):
             guard let image = item.image else { return }
-            let activityVC = UIActivityViewController(activityItems: [image], applicationActivities: nil)
+            let activityVC = activityController(with: [image])
             self.present(activityVC, animated: true)
 
         case (_ as VideoViewController, let item as VideoView):
             guard let videoUrl = ((item.player?.currentItem?.asset) as? AVURLAsset)?.url else { return }
-            let activityVC = UIActivityViewController(activityItems: [videoUrl], applicationActivities: nil)
+            let activityVC = activityController(with: [videoUrl])
             self.present(activityVC, animated: true)
 
         default:  return
         }
+    }
+    
+    private func activityController(with items: [Any] ) -> UIActivityViewController {
+        let activityVC = UIActivityViewController(activityItems: items, applicationActivities: nil)
+        
+        // for MacOS and iPad the activity view needs a source rect and view, otherwise it will crash
+        
+        if UIDevice.current.userInterfaceIdiom == .pad { /// .pad is relevant for iPad and MacCatalyst
+            if let popoverController = activityVC.popoverPresentationController {
+                popoverController.sourceRect = CGRect(x: UIScreen.main.bounds.width / 2, y: UIScreen.main.bounds.height / 2, width: 0, height: 0)
+                popoverController.sourceView = self.view
+                popoverController.permittedArrowDirections = UIPopoverArrowDirection(rawValue: 0)
+            }
+        }
+        
+        return activityVC
     }
 
     public func itemController(_ controller: ItemController, didSwipeToDismissWithDistanceToEdge distance: CGFloat) {

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,33 @@
+// swift-tools-version:5.1
+//
+//  Package.swift
+//
+//  Copyright (c) 2020 Alamofire Software Foundation (http://alamofire.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import PackageDescription
+
+let package = Package(name: "ImageViewer",
+                      platforms: [.iOS(.v13)],
+                      products: [.library(name: "ImageViewer", targets: ["ImageViewer"])],
+                      targets: [.target(name: "ImageViewer",
+                                        path: "ImageViewer/Source")],
+                      swiftLanguageVersions: [.v5])

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ pod 'ImageViewer'
 github "Krisiacik/ImageViewer"
 ```
 
+### Swiftpackage
+
+Just add the repository URL in Xcode.
+
+ 
 ## Sample Usage
 
 For a detailed example, see the [Example](https://github.com/Krisiacik/ImageViewer/tree/master/Example)!


### PR DESCRIPTION
I had issues with Carthage and the new xcode12. It looks like that Carthage currently no more is usable with Xcode12 and iOS simulator. When you build the frameworks with 'carthage update' or 'carthage build' there comes an error. A deeper look says "have the same architectures (arm64) and can't be in the same fat output file" So the iOS Simulator build is missing in the framework. This already is discussed as issue here https://github.com/Carthage/Carthage/issues/3019 and here https://github.com/ashleymills/Reachability.swift/issues/370 

My workarround was just to move from carthage to Swift Packages.  I found out that is really easy to provide an existing iOS framework as Swift Package. Just create a fork of it, put there a configured Package.swift file into the root folder, double click it in finder to open it in Xcode as a SWIFT PACKAGE PROJECT !!! - now just add/change the path to the source files in the Package.swift file. When you could build the project, all is fine and push it to your repo - thats it. For this works. 

Maybe you want to add Swift Package support ?